### PR TITLE
Kernel#open->URI#open

### DIFF
--- a/lib/sist02/cinii.rb
+++ b/lib/sist02/cinii.rb
@@ -6,7 +6,7 @@ module Sist02
   module CiNii
     # enable required program to call following functions
     module_function
-    
+
     def article_ref naid
 
       begin
@@ -31,7 +31,7 @@ module Sist02
         content = get_content url
         common_info = get_common_info content
         edition = content["prism:edition"]
-        ris = open("http://ci.nii.ac.jp/ncid/#{ncid}.ris").read
+        ris = URI.open("http://ci.nii.ac.jp/ncid/#{ncid}.ris").read
         edition = ris.match(/ET\s{2}-\s(.*)\r/) ? ris.match(/ET\s{2}-\s(.*)\r/)[1] : nil
         publisher = ris.match(/PB\s{2}-\s(.*)\r/) ? ris.match(/PB\s{2}-\s(.*)\r/)[1] : nil
         page = ris.match(/EP\s{2}-\s.*?(\d*?p)/) ? ris.match(/EP\s{2}-\s.*?(\d*?p)/)[1] : 'ページ数不明'
@@ -44,7 +44,7 @@ module Sist02
     end
 
     def dissertation_ref naid
-      
+
       begin
 
         url = "http://ci.nii.ac.jp/naid/#{naid}.json"
@@ -58,11 +58,11 @@ module Sist02
     end
 
     def get_content url
-      html = open(url).read
+      html = URI.open(url).read
       json = JSON.parser.new(html)
       json.parse["@graph"][0]
     end
-    
+
 
     def get_common_info content
       common_info = {}


### PR DESCRIPTION
In Ruby 2.7:

```bash
$ sist02 cinii_articles 110004867788
/home/eggplants/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/sist02-0.4.1/lib/sist02/cinii.rb:61: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
門島伸佳, 富山大学大学院:射水市立新湊南部中学校. 「分析批評」による文学教材の読み書き関連指導の実践的研究 : 思考力の関連による読書感想文指導への応用(自由研究発表,第110回 全国大学国語教育学会・岩手大会). 全国大学国語教育学会国語科教育研究：大会研究発表要旨集. 2006, vol. 110, no. 0, p. 161-164.
/home/eggplants/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/sist02-0.4.1/lib/sist02/cinii.rb:61: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```